### PR TITLE
Add API documentation autogeneration

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,53 @@
+import coreapi
+from rest_framework.schemas import SchemaGenerator as BaseSchemaGenerator
+from rest_framework.compat import urlparse
+
+
+class SchemaGenerator(BaseSchemaGenerator):
+    def get_link(self, path, method, callback, view):
+        """
+        Return a `coreapi.Link` instance for the given endpoint.
+        """
+        fields = self.get_path_fields(path, method, callback, view)
+        fields += self.get_serializer_fields(path, method, callback, view)
+        fields += self.get_pagination_fields(path, method, callback, view)
+        fields += self.get_filter_fields(path, method, callback, view)
+
+        if fields and any([field.location in ('form', 'body') for field in fields]):
+            encoding = self.get_encoding(path, method, callback, view)
+        else:
+            encoding = None
+
+        description = self.get_description(path, method, callback, view)
+
+        return coreapi.Link(
+            url=urlparse.urljoin(self.url, path),
+            action=method.lower(),
+            encoding=encoding,
+            description=description,
+            fields=fields,
+            transform=None, # Not handled, but here for future reference
+        )
+
+    def get_description(self, path, method, callback, view):
+        if hasattr(callback, 'actions'):
+            action_name = callback.actions[method.lower()]
+            action = (getattr(view, action_name))
+            if action.__doc__:
+                return self._get_description(view, action)
+        
+        return self._get_description(view, None)
+
+    def _get_description(self, view, action=None):
+        def unwrap(s):
+            if s:
+                return "\n".join([l.strip() for l in s.splitlines()])
+        
+        generic = view.__doc__
+        specific = action.__doc__
+
+        if specific:
+            specific += "\n\n"
+        
+        return "{1}{0}".format(unwrap(generic),
+                               unwrap(specific))

--- a/api/urls.py
+++ b/api/urls.py
@@ -16,12 +16,16 @@ Including another URLconf
 from django.conf.urls import url
 from rest_framework import routers
 from rest_framework.urlpatterns import include
+
+from .views import schema_view
 from jwt_knox.viewsets import JWTKnoxAPIViewSet
+
 
 router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'auth/jwt', JWTKnoxAPIViewSet, base_name='jwt_knox')
 
 urlpatterns = [
+    url(r'docs', schema_view, name='swagger-ui'),
     url(r'', include(router.urls)),
     url(r'accounts/', include('accounts.urls')),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,30 +1,37 @@
 from rest_framework.decorators import (api_view, permission_classes,
-    renderer_classes)
+                                       renderer_classes)
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import CoreJSONRenderer
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
-from rest_framework.schemas import SchemaGenerator
 from rest_framework_swagger.renderers import (OpenAPIRenderer,
-    SwaggerUIRenderer)
+                                              SwaggerUIRenderer)
+
+from .schemas import SchemaGenerator
 
 
 @api_view()
 @permission_classes((AllowAny, ))
-@renderer_classes((OpenAPIRenderer, CoreJSONRenderer, SwaggerUIRenderer, ))
+@renderer_classes((OpenAPIRenderer,
+                   CoreJSONRenderer,
+                   SwaggerUIRenderer, ))
 def schema_view(request):
     generator = SchemaGenerator(title='XEA API')
     return Response(generator.get_schema(request=request))
+
 
 @api_view()
 def api_root(request, format=None):
     return Response({'message': 'Welcome to XEA'})
     return Response({
-        '_self': reverse('root', request=request, format=format),
+        '_self': reverse(
+            'root', request=request, format=format),
         '_links': {
-            'docs': reverse('swagger-ui', request=request, format=format),
+            'docs': reverse(
+                'swagger-ui', request=request, format=format),
             'auth': {
-                'jwt': reverse('jwt_knox-get-token', request=request, format=format),
+                'jwt': reverse(
+                    'jwt_knox-get-token', request=request, format=format),
             },
         },
     })

--- a/api/views.py
+++ b/api/views.py
@@ -3,6 +3,7 @@ from rest_framework.decorators import (api_view, permission_classes,
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import CoreJSONRenderer
 from rest_framework.response import Response
+from rest_framework.reverse import reverse
 from rest_framework.schemas import SchemaGenerator
 from rest_framework_swagger.renderers import (OpenAPIRenderer,
     SwaggerUIRenderer)
@@ -14,3 +15,16 @@ from rest_framework_swagger.renderers import (OpenAPIRenderer,
 def schema_view(request):
     generator = SchemaGenerator(title='XEA API')
     return Response(generator.get_schema(request=request))
+
+@api_view()
+def api_root(request, format=None):
+    return Response({'message': 'Welcome to XEA'})
+    return Response({
+        '_self': reverse('root', request=request, format=format),
+        '_links': {
+            'docs': reverse('swagger-ui', request=request, format=format),
+            'auth': {
+                'jwt': reverse('jwt_knox-get-token', request=request, format=format),
+            },
+        },
+    })

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,16 @@
-from django.shortcuts import render
+from rest_framework.decorators import (api_view, permission_classes,
+    renderer_classes)
+from rest_framework.permissions import AllowAny
+from rest_framework.renderers import CoreJSONRenderer
+from rest_framework.response import Response
+from rest_framework.schemas import SchemaGenerator
+from rest_framework_swagger.renderers import (OpenAPIRenderer,
+    SwaggerUIRenderer)
 
-# Create your views here.
+
+@api_view()
+@permission_classes((AllowAny, ))
+@renderer_classes((OpenAPIRenderer, CoreJSONRenderer, SwaggerUIRenderer, ))
+def schema_view(request):
+    generator = SchemaGenerator(title='XEA API')
+    return Response(generator.get_schema(request=request))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ django-cors-middleware>=1.3.1,<2.0.0
 django-debug-toolbar==1.5
 django-filter==0.13.0
 django-rest-knox==2.2.0
-djangorestframework==3.4.0
+django-rest-swagger>=2.0.4,<2.1.0
+djangorestframework>=3.4.4,<3.5.0
 idna==2.1
 PyJWT>=1.4.0,<2.0.0
 Markdown==2.6.6

--- a/xea_core/settings.py
+++ b/xea_core/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'debug_toolbar',
     'rest_framework',
+    'rest_framework_swagger',
     'knox',
     'jwt_knox',
     'api',
@@ -154,6 +155,27 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     )
+}
+
+
+# Swagger settings
+SWAGGER_SETTINGS = {
+    'APIS_SORTER': True,
+    'DOC_EXPANSION': 'list',
+    'JSON_EDITOR': True,
+    'OPERATIONS_SORTER': 'method',
+    'SHOW_REQUEST_HEADERS': True,
+
+    'SECURITY_DEFINITIONS': {
+        'basic': {
+            'type': 'basic',
+        },
+        'jwt': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header',
+        },
+    },
 }
 
 


### PR DESCRIPTION
Django REST Framework includes schema introspection. Using that and
django-rest-swagger, we provide an /api/docs endpoint for obtaining
machine-readable (and human-readable, through an AJAX UI) API
documentation on the provided service.

Instead of relying on human-written documentation for our API,
api_view docstrings are obtained as the user-facing documentation, so
that documentation is much nearer the code, and code changes can make
their explanation to the documentation more easily.
