### PR TITLE
Switch django-cors-headers to django-cors-middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cffi==1.7.0
 cryptography==1.4
 Django==1.9.8
-django-cors-headers>=1.1.0,<2.0.0
+django-cors-middleware>=1.3.1,<2.0.0
 django-debug-toolbar==1.5
 django-filter==0.13.0
 django-rest-knox==2.2.0


### PR DESCRIPTION
The original django-cors-headers module at
https://github.com/ottoyiu/django-cors-headers seems to have been
unmaintained for two years.

There is a more recent fork at
https://github.com/zestedesavoir/django-cors-middleware which is
currently maintained and supports the new Django 1.10 middleware.

Switch to this package is encouraged because the former one does not
seem maintained anymore.
