### PR TITLE
Upgrade to Django 1.10

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,11 +1,13 @@
+from rest_framework.test import APITestCase
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.core import mail
-from django.core.urlresolvers import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.reverse import reverse
+
 from .models import UserProfile
+
 
 # Default test user data
 username = 'user'

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -1,9 +1,11 @@
 import logging
-from django.core.mail import send_mail
+
 from django.conf import settings
-from django.core.urlresolvers import reverse
-from django.template.loader import get_template
 from django.contrib.auth.tokens import default_token_generator
+from django.core.mail import send_mail
+from django.template.loader import get_template
+from rest_framework.reverse import reverse
+
 
 logger = logging.getLogger(__name__)
 

--- a/jwt_knox/tests.py
+++ b/jwt_knox/tests.py
@@ -1,8 +1,8 @@
 from rest_framework.test import APITestCase
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
 from rest_framework import status
+from rest_framework.reverse import reverse
 
 
 class APIAuthTest(APITestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cffi==1.7.0
+colorlog>=2.7.0,<2.8
 cryptography==1.4
-Django==1.9.8
+Django[argon2]>=1.10,<1.11
 django-cors-middleware>=1.3.1,<2.0.0
 django-debug-toolbar==1.5
 django-filter==0.13.0

--- a/xea_core/settings.py
+++ b/xea_core/settings.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     'accounts',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     # Django CORS must be before CommonMiddlware if using USE_ETAGS=True
@@ -78,8 +78,47 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'xea_core.wsgi.application'
+LOGGING = {
+    'version': 1,
+    'disable_existing_logger': False,
+    'formatters': {
+        'color': {
+            '()': 'colorlog.ColoredFormatter',
+            'format': '%(log_color)s%(levelname)-8s %(message)s%(reset)s',
+            'log_colors': {
+                'DEBUG': 'bold_black',
+                'INFO': 'cyan',
+                'WARNING': 'yellow',
+                'ERROR': 'red',
+                'CRITICAL': 'bold_red,bg_white',
+            },
+            'reset': True,
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'color',
+        },
+    },
+    'loggers': {
+        'django': {
+            'formatter': 'color',
+            'handlers': ['console'],
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
+            'propagate': True,
+        },
+    },
+}
 
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+]
+
+WSGI_APPLICATION = 'xea_core.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases


### PR DESCRIPTION
In this change we also update `reverse` to use `from rest_framework.reverse import reverse` instead of Django's now deprecated `from django.core.urlresolvers import reverse`.

Yes, it is a different function, but we are building a REST Framework app. Tests seem unaffected by the change (one was failing and still only one is failing).
