### PR TITLE
Move permissions classes to 'api' module

### DIFF
--- a/accounts/viewsets.py
+++ b/accounts/viewsets.py
@@ -4,11 +4,11 @@ from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 
-from .serializers import UserSerializer, UserPasswordSerializer
-from .permissions import IsAdminOrSelf
+from api.permissions import IsAdminOrSelf
+from . import utils
 from .models import UserProfile
 from .serializers import UserProfileSerializer
-from . import utils
+from .serializers import UserSerializer, UserPasswordSerializer
 
 
 class UserViewSet(viewsets.ModelViewSet):

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -11,8 +11,3 @@ class IsAdminOrSelf(permissions.BasePermission):
         if request.user == self.get_owner(obj):
             return True
         return False
-
-
-class IsPlaceOwnerOrAdmin(IsAdminOrSelf):
-    def get_owner(self, obj):
-        return obj.user

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -13,6 +13,6 @@ class IsAdminOrSelf(permissions.BasePermission):
         return False
 
 
-class IsProfileOwnerOrStaff(IsAdminOrSelf):
+class IsPlaceOwnerOrAdmin(IsAdminOrSelf):
     def get_owner(self, obj):
         return obj.user


### PR DESCRIPTION
Since permissions classes are mean to be shared among all the modules that will interact with the api, it seems more logical to move the accounts.permissions.py file to more "centralized" position like the /api folder.
