### PR TITLE
Remove the failing accounts test.

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -326,16 +326,3 @@ class UserProfileTest(APITestCase):
         response = self.client.get(url)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertTrue('profile' in response.data)
-
-    def test_profile_update_after_password_change(self):
-        user = get_user_model().objects.get(pk=1)
-        change_password_url = reverse('user-change-password', kwargs={'pk': user.pk})
-        profile_url = reverse('user-update-profile', kwargs={'pk': user.pk})
-        self.client.force_login(user)
-        response1 = self.client.put(path=profile_url, data=self.default_test_payload)
-        self.assertEquals(response1.status_code, status.HTTP_200_OK)
-        response2 = self.client.post(path=change_password_url, data={'password': 'password2'})
-        self.assertEqual(response2.status_code, status.HTTP_200_OK)
-        response3 = self.client.put(path=profile_url, data=self.default_test_payload)
-        self.assertEqual(response2.status_code, status.HTTP_401_UNAUTHORIZED)
-


### PR DESCRIPTION
The test had several intrinsic problems, but most importantly, it did
not test what it was supposed to. This escaped code-review.

The test was created to test whether a user could still access the API
after changing their password. However, as no real authentication
mechanism is provided, but instead the user is forced onto an
authenticated request, via `.force_login()`, it is _impossible_ to make
the requests presently invalid.

If such behavior is desired, it should be implemented and tested in the
proper authentication backend, most probably in our own jwt_knox
application, where we have access to tokens and we don't really need
cross-application coupling.
