### PR TITLE
Add drf-swagger-extras for @responds decorator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ django-filter==0.13.0
 django-rest-knox==2.2.0
 django-rest-swagger>=2.0.4,<2.1.0
 djangorestframework>=3.4.4,<3.5.0
+drf-swagger-extras>=0.1.0.dev1,<2.0
 idna==2.1
 PyJWT>=1.4.0,<2.0.0
 Markdown==2.6.6


### PR DESCRIPTION
drf-swagger-extras is a Python package implementing a better
SchemaGenerator which may use a @responds decorator in APIViews so that
the generated OpenAPI can include such information in the response.

The implementing code is at:
https://github.com/ssaavedra/drf-swagger-extras/blob/master/drf_swagger_extras/

The PyPI package is at:
https://pypi.python.org/pypi/drf-swagger-extras
